### PR TITLE
Added pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,28 @@
+Contributes to # (add issue number here. i.e. `#302`)
+
+## What did you do?
+
+## Why did you do it?
+
+## How have you tested it?
+
+## Were docs updated if needed?
+
+- [ ] No
+- [ ] Yes
+- [ ] N/A
+
+#### Type of change
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+
+#### Checklist:
+
+- [ ] My code follows the style guidelines of this project
+- [ ] I have performed a self-review of my own code
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] My changes generate no new console logs
+- [ ] Fixes entire issue
+- [ ] Partial fix for issue


### PR DESCRIPTION
Contributes to #41 

## What did you do?
Added pull_request_template.md file in .github folder

## Why did you do it?
When a user opens a pull request in the repository, a generic template will show up for all users.

